### PR TITLE
Fix note mismatch bug

### DIFF
--- a/lib/src/models/note.dart
+++ b/lib/src/models/note.dart
@@ -9,6 +9,10 @@ class Note {
 
   // bool get isNew => this.title.isEmpty && this.content.isEmpty;
 
+  // We're initialising the date outside the constructor brackets because
+  // The default value of an optional parameter must be constant.
+  // See error: dartnon_constant_default_value
+
   Note();
 
   Note.dummy(
@@ -18,6 +22,14 @@ class Note {
           'Colonial Masters decided to colonise. What the hell am I saying?',
       this.tagName = ''})
       : this.dateCreated = DateTime.now().toIso8601String();
+
+  Note.copyOf(Note note) {
+    id = note.id;
+    title = note.title;
+    content = note.content;
+    dateCreated = note.dateCreated;
+    tagName = note.tagName;
+  }
 
   Note.fromMap(Map json) {
     id = json['id'];
@@ -38,7 +50,7 @@ class Note {
   @override
   String toString() {
     return ''
-        'id - $id, '
+        // 'id - $id, '
         'title - $title, '
         'date_created - $dateCreated, '
         'content - $content, ';

--- a/lib/src/notifiers/note_notifier.dart
+++ b/lib/src/notifiers/note_notifier.dart
@@ -14,16 +14,16 @@ class NoteNotifier with ChangeNotifier {
   // NotesDBService _localDBService;
   // Database _db;
 
-  List<Note> _notes = [...getDummyNotes()];
+  List<Note> _notes = [];
 
-  UnmodifiableListView<Note> get notes => UnmodifiableListView(_notes);
+  List<Note> get notes => _notes;
 
   // Future<void> init() async =>
   //     _localDBService = await NotesDBService.getInstance();
 
   Future<void> addNote(Note note) async {
     final dbService = await NotesDBService.getInstance();
-    await dbService.addNote(note);
+    // await dbService.addNote(note);
     _notes.add(note);
     notifyListeners();
   }
@@ -33,5 +33,22 @@ class NoteNotifier with ChangeNotifier {
     final notes = await dbService.getNotes();
     _notes.addAll(notes);
     return notes;
+  }
+
+  Future editNote(Note editedNote) async{
+    final dbService = await NotesDBService.getInstance();
+    // dbService.editNote(editedNote);
+
+    // edit note in list
+
+    // Get the movie's index
+
+    // _notes.indexOf(editedNote);
+
+    // _notes.replaceRange();
+
+  
+
+    notifyListeners();
   }
 }

--- a/lib/src/screens/home.dart
+++ b/lib/src/screens/home.dart
@@ -25,15 +25,17 @@ class _MyHomeScreenState extends State<MyHomeScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final notes = await _noteNotifier.getNotes();
-      for (var note in notes) {
-        print(note);
-      }
+      // for (var note in notes) {
+      //   print(note);
+      // }
+
+      setState(() {});
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // print(getDummyNotes().isNotEmpty);
+     print('rebuilding home.dart');
     _noteNotifier = NoteNotifier.of(context);
     return Scaffold(
       appBar: AppBar(
@@ -108,7 +110,7 @@ class _MyHomeScreenState extends State<MyHomeScreen> {
   }
 
   void _goToViewNoteScreen({Note note, bool isNewNote = false}) {
-    print(note.title);
+    // print('entering note: $note');
     Navigator.push(
       context,
       MaterialPageRoute(builder: (context) {

--- a/lib/src/screens/view_note.dart
+++ b/lib/src/screens/view_note.dart
@@ -28,7 +28,7 @@ class _ViewNoteScreenState extends State<ViewNoteScreen> {
   @override
   void initState() {
     super.initState();
-    _note = widget.note;
+    _note = Note.copyOf(widget.note);
     _isNewNote = widget.isNewNote;
     _titleController = TextEditingController(text: _note.title);
     _contentController = TextEditingController(text: _note.content);
@@ -75,8 +75,6 @@ class _ViewNoteScreenState extends State<ViewNoteScreen> {
                   onTap: () {
                     _startEditingIfViewing();
                   },
-                  // onEditingComplete: (){},
-                  // onSubmitted: (value){},
                   style: TextStyle(fontSize: 30),
                   decoration: InputDecoration(
                     hintText: 'Title',
@@ -139,27 +137,29 @@ class _ViewNoteScreenState extends State<ViewNoteScreen> {
     _bundleNote();
     print('Is new note: $_isNewNote');
 
-    // View mode
+    // In view mode
     if (!_isInEditMode) {
       return true; // Pop screen if in view mode
     }
 
-    //Edit mode
+    //In edit mode
     if (_isInEditMode) {
       FocusScope.of(context)
           .requestFocus(FocusNode()); // Unfocus from textfields
 
+      // Add note
       if (_isNewNote) {
-        // print('Is new note: $_isNewNote');
         print('Added note...');
-
-       await _noteNotifier.addNote(_note);
+        await _noteNotifier.addNote(_note);
       }
 
+      // Update note
       if (!_isNewNote) {
-        // print('Is new note: $_isNewNote');
-        print('Updated note...');
-        // Update note here
+        // print('Updated note...');
+        // Update note here if there is any change
+        // await _noteNotifier.editNote(_note);
+
+        print('saving note: $_note');
       }
 
       setState(() {
@@ -167,11 +167,13 @@ class _ViewNoteScreenState extends State<ViewNoteScreen> {
       });
     }
 
-    return false;
+    return false; // Don't pop screen if in edit mode
   }
 
   void _bundleNote() {
-    _note.title = _titleController.text;
+    _note.title = _titleController.text.isNotEmpty
+        ? _titleController.text
+        : 'Untitled Note';
     _note.content = _contentController.text;
   }
 

--- a/lib/src/services/db_service.dart
+++ b/lib/src/services/db_service.dart
@@ -40,7 +40,9 @@ class NotesDBService {
     print(responseCode);
   }
 
-  editNote() {}
+  Future editNote() {
+    // _db.update()
+  }
 
   Future<List<Note>> getNotes() async {
     final maps = await _db.query(tableName);


### PR DESCRIPTION
Fix bug where after editing a note, the fields of the note displayed in the edit screen seem to be different from the corresponding list tile note in the home screen. Once we hot reload, the changes seem to reflect